### PR TITLE
Backcast EoL rates

### DIFF
--- a/R/calcPlGoodShare.R
+++ b/R/calcPlGoodShare.R
@@ -23,6 +23,11 @@ calcPlGoodShare <- function() {
     dplyr::mutate(share = .data$Value_sum / sum(.data$Value_sum, na.rm = TRUE)) %>%
     dplyr::ungroup()
 
+  regional_share <- as.magpie(
+    regional_df[c("Region", "Year", "Data2", "share")],
+    spatial = 1, temporal = 2
+  )
+
   # ---------------------------------------------------------------------------
   # Aggregate shares to country level
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Backcast EoL rates to 1950, assuming 100% landfilling before 1980 (based on Geyer et al. 2017 SI fig.S5), linearly interpolating landfilling, incineration and recycling rates between 1980-2000, and assuming constant collection rates before 2000.