### PR TITLE
Fix plastic waste trade polymer split

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3938611'
+ValidationKey: '3959232'
 AutocreateReadme: yes
 AutocreateCITATION: yes
 AcceptedWarnings:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrmfa: Input data generation for the REMIND MFA'
-version: 1.9.1
+version: 1.9.2
 date-released: '2026-06-17'
 abstract: The mrmfa packages contains data preprocessing for the REMIND MFA.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,3 +42,4 @@ Suggests:
     testthat
 Encoding: UTF-8
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrmfa
 Title: Input data generation for the REMIND MFA
-Version: 1.9.1
+Version: 1.9.2
 Date: 2026-06-17
 Authors@R: c(
     person("Jakob", "Dürrwächter", , "jakobdu@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcPlBACI.R
+++ b/R/calcPlBACI.R
@@ -64,7 +64,11 @@ calcPlBACI <- function(subtype, category, HS) {
       rename("sector" = "Target")
 
     # map UNEP-NGP polymers to polymers used in REMIND-MFA
-    polymer_map <- toolGetMapping("polymermappingUNEP_NGP.csv", type = "sectoral", where = "mrmfa")
+    if (category == "Waste"){
+      polymer_map <- toolGetMapping("polymermappingUNEP_NGP_waste.csv", type = "sectoral", where = "mrmfa")
+    } else {
+      polymer_map <- toolGetMapping("polymermappingUNEP_NGP.csv", type = "sectoral", where = "mrmfa")
+    }
     # use polymer use by sector as weights (summarize over all Regions,
     # as polymer share by sector is constant over all Regions in OECD data);
     # use total polymer use over all sectors as weights for "General" sector

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the REMIND MFA
 
-R package **mrmfa**, version **1.9.1**
+R package **mrmfa**, version **1.9.2**
 
    [![R build status](https://github.com/pik-piam/mrmfa/workflows/check/badge.svg)](https://github.com/pik-piam/mrmfa/actions) [![codecov](https://codecov.io/gh/pik-piam/mrmfa/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrmfa) 
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jakob Dürrwächter <jakobdu@pik-
 
 To cite package **mrmfa** in publications use:
 
-Dürrwächter J, Weiss B, Schweiger L, Benke F, Hosak M, Zhang Q (2026). "mrmfa: Input data generation for the REMIND MFA." Version: 1.9.1, <https://github.com/pik-piam/mrmfa>.
+Dürrwächter J, Weiss B, Schweiger L, Benke F, Hosak M, Zhang Q (2026). "mrmfa: Input data generation for the REMIND MFA." Version: 1.9.2, <https://github.com/pik-piam/mrmfa>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,6 +49,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-06-17},
   year = {2026},
   url = {https://github.com/pik-piam/mrmfa},
-  note = {Version: 1.9.1},
+  note = {Version: 1.9.2},
 }
 ```

--- a/inst/extdata/sectoral/polymermappingUNEP_NGP_waste.csv
+++ b/inst/extdata/sectoral/polymermappingUNEP_NGP_waste.csv
@@ -1,0 +1,10 @@
+Source;Target;Sector
+Other;PET;
+Other;PP;
+Other;PUR;
+Other;Others;
+PS;ABS_ASA_SAN;
+PS;PS;
+PVC;PVC;
+LDPE;LDPE;
+LDPE;HDPE;

--- a/man/mrmfa-package.Rd
+++ b/man/mrmfa-package.Rd
@@ -20,7 +20,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Jakob Dürrwächter \email{jakobdu@pik-potsdam.de}
   \item Bennet Weiss \email{bennet.weiss@pik-potsdam.de}
   \item Leonie Schweiger \email{leonie.schweiger@pik-potsdam.de}
   \item Falk Benke \email{benke@pik-potsdam.de}


### PR DESCRIPTION
For plastic waste trade, the "Others" polymer category of the UNEP-NGP categorization is broader than for primary and good trade. For instance, there is no specific PET waste trade. This is now accounted for by using a different mapping for waste trade.